### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Student.Achieve.Api/Student.Achieve.Common/Student.Achieve.Common.csproj
+++ b/Student.Achieve.Api/Student.Achieve.Common/Student.Achieve.Common.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetCore.NPOI" Version="1.2.2" />
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="DotNetCore.NPOI" Version="1.2.3" />
+    <PackageReference Include="log4net" Version="2.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
-    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.20" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi@anjoy8, I found an issue in the Student.Achieve.Common.csproj:

Packages DotNetCore.NPOI v1.2.2, log4net v2.0.8, Microsoft.Extensions.Caching.Memory v3.1.5, Microsoft.Extensions.Configuration.Json v3.1.5 and StackExchange.Redis v2.1.58 transitively introduce 110 dependencies into Student.Achieve.Manager’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Student-Achieve-Manager.html)), while DotNetCore.NPOI v1.2.3, log4net v2.0.11, Microsoft.Extensions.Caching.Memory v3.1.9, Microsoft.Extensions.Configuration.Json v3.1.9 and StackExchange.Redis v2.2.20 can only introduce 77 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Student-Achieve-Manager_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose